### PR TITLE
Added export static compute address from wallet provider

### DIFF
--- a/build.js
+++ b/build.js
@@ -4,7 +4,7 @@ const esbuild = require('esbuild')
 const plugin = require('node-stdlib-browser/helpers/esbuild/plugin')
 const stdLibBrowser = require('node-stdlib-browser')
 ;(async () => {
-  console.time('Build time')
+  console.time('IIFE Build time')
   const result = await esbuild
     .build({
       entryPoints: ['src/index.ts'],
@@ -26,7 +26,40 @@ const stdLibBrowser = require('node-stdlib-browser')
       console.log({ error: e })
       process.exit(0)
     })
-  console.timeEnd('Build time')
+  console.timeEnd('IIFE Build time')
+  if (result.errors && result.errors.length) {
+    console.log({ errors: result.errors })
+  } else {
+    console.info('Compiled successfully!')
+  }
+  if (result.warnings && result.warnings.length) {
+    console.log({ warnings: result.warnings })
+  }
+})()
+;(async () => {
+  console.time('ESM Build time')
+  const result = await esbuild
+    .build({
+      entryPoints: ['src/index.ts'],
+      bundle: true,
+      target: ['chrome58', 'firefox57', 'safari11', 'edge18'],
+      globalName: 'arcana.wallet',
+      inject: [require.resolve('node-stdlib-browser/helpers/esbuild/shim')],
+      plugins: [plugin(stdLibBrowser)],
+      define: {
+        global: 'window',
+        process: 'process',
+        Buffer: 'Buffer',
+      },
+      format: 'esm',
+      outfile: 'dist/standalone/wallet.esm.js',
+      minify: true,
+    })
+    .catch((e) => {
+      console.log({ error: e })
+      process.exit(0)
+    })
+  console.timeEnd('ESM Build time')
   if (result.errors && result.errors.length) {
     console.log({ errors: result.errors })
   } else {

--- a/readme.md
+++ b/readme.md
@@ -62,6 +62,12 @@ WalletProvider.encryptWithPublicKey({
 })
 ```
 
+### Compute Address
+
+```ts
+const address = WalletProvider.computeAddress(publicKey: string);
+```
+
 ### Login/logout
 
 Social login

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import { ArcanaProvider } from './provider'
 import IframeWrapper from './iframeWrapper'
 import { encryptWithPublicKey, cipher } from 'eth-crypto'
-import { getWalletType } from './utils'
+import { getWalletType, computeAddress } from './utils'
 import { setNetwork, getConfig, setIframeDevUrl } from './config'
 import {
   IAppConfig,
@@ -34,6 +34,10 @@ class WalletProvider {
       input.message
     )
     return cipher.stringify(ciphertext)
+  }
+
+  public static computeAddress(publicKey: string): string {
+    return computeAddress(publicKey)
   }
 
   private state: State

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -94,7 +94,7 @@ const getWalletPosition = (
   return { bottom: positionDistance, [position]: positionDistance }
 }
 
-export function verifyMode(w: WalletType, a: AppMode | undefined): AppMode {
+function verifyMode(w: WalletType, a: AppMode | undefined): AppMode {
   const allowedModes = ModeWalletTypeRelation[w]
   if (a !== undefined) {
     if (!allowedModes.includes(a)) {
@@ -106,11 +106,17 @@ export function verifyMode(w: WalletType, a: AppMode | undefined): AppMode {
   }
 }
 
+function computeAddress(publicKey: string) {
+  return ethers.utils.computeAddress(publicKey)
+}
+
 export {
-  getWalletType,
+  computeAddress,
   createDomElement,
+  getWalletType,
   setWalletSize,
   getWalletSize,
   setWalletPosition,
   getWalletPosition,
+  verifyMode,
 }


### PR DESCRIPTION
## Describe your changes

Added helper static function to `WalletProvider` class
```ts
import { WalletProvider } from '@arcana/wallet'

const address = WalletProvider.computeAddress('0x04...')
```
Made it static function so that it can be used before any instance creation.
Ideally I would like to have it like

```ts
import { WalletProvider, Utils } from '@arcana/wallet'

const address = Utils.computeAddress('0x04...')
// Also move `encryptWithPublicKey` function to utils.
const cipher = Utils.encryptWithPublicKey({ message: "test", publicKey: "0x04" })
```

## Issue ticket number and link

- [AR-2695](https://team-1624093970686.atlassian.net/browse/AR-2695)

## Checklist before requesting a review

- [x] You have performed a self-review of your own code
- [x] You are using approved terminology
- [x] Your code builds clean without any errors or warnings