### PR TITLE
Resolves - [AR-2759] - Wallet bubble appears in widget mode.

### DIFF
--- a/src/iframeWrapper.ts
+++ b/src/iframeWrapper.ts
@@ -233,7 +233,8 @@ export default class IframeWrapper {
   }
 
   private closeWidgetIframe() {
-    this.widgetBubble.style.display = 'flex'
+    const isFullMode = this.appMode === AppMode.Full
+    this.widgetBubble.style.display = isFullMode ? 'flex' : 'none'
     this.widgetIframeContainer.style.display = 'none'
   }
 


### PR DESCRIPTION
Resolves [AR-2759](https://team-1624093970686.atlassian.net/browse/AR-2759)

1. In `closeWidgetIframe` function, set `display` property of Wallet Bubble to `flex` if the app mode is full else set to `none`.