### PR TITLE
[AR-2797] Close button on the wallet bubble should only hide the wallet

### DIFF
--- a/src/iframeWrapper.ts
+++ b/src/iframeWrapper.ts
@@ -232,7 +232,7 @@ export default class IframeWrapper {
   }
 
   private onCloseBubbleClick() {
-    this.params.destroyWalletUI()
+    this.widgetBubble.style.display = 'none'
   }
 
   // Todo: add remove event listener for "resize" event

--- a/src/iframeWrapper.ts
+++ b/src/iframeWrapper.ts
@@ -51,11 +51,6 @@ export default class IframeWrapper {
     this.initWalletUI()
   }
 
-  public destroyUIElements() {
-    this.widgetBubble.remove()
-    this.widgetIframeContainer.remove()
-  }
-
   public onReceivingPendingRequestCount(count: number) {
     const reqCountBadgeEl = document.getElementById('req-count-badge')
     if (!reqCountBadgeEl) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -91,7 +91,6 @@ class AuthProvider {
       iframeUrl: this.state.iframeUrl,
       appConfig: this.appConfig,
       position: position,
-      destroyWalletUI: this.destroyWalletUI,
     })
 
     const walletType = await getWalletType(this.appId)
@@ -212,13 +211,6 @@ class AuthProvider {
   /**
    * @internal
    */
-  destroyWalletUI = () => {
-    if (this.iframeWrapper) {
-      this.iframeWrapper.destroyUIElements()
-    }
-    this.iframeWrapper = null
-  }
-
   get provider() {
     if (this._provider) {
       return this._provider

--- a/src/typings.ts
+++ b/src/typings.ts
@@ -11,7 +11,6 @@ export interface IframeWrapperParams {
   iframeUrl: string
   appConfig: AppConfig
   position: Position
-  destroyWalletUI: () => void
 }
 
 export interface InitInput {


### PR DESCRIPTION
1. Removed all the code that destroys Wallet-UI bubble and iframe.
2. Replaced code in `onCloseBubbleClick` handle to set the display mode of bubble to `none`. 

Demo Video:
https://www.loom.com/share/7b4f3b458e7f426b97a5c71537b18f2a