### PR TITLE
[AR-3540] Added publicKey and address in getUser method

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,19 +1,19 @@
-class ArcanaWalletError extends Error {
+class ArcanaAuthError extends Error {
   constructor(code: string, public message: string) {
     super(code)
   }
 }
 
-const UserNotLoggedInError = new ArcanaWalletError(
+const UserNotLoggedInError = new ArcanaAuthError(
   'user_not_logged_in',
   'User is not logged in'
 )
-const WalletNotInitializedError = new ArcanaWalletError(
+const WalletNotInitializedError = new ArcanaAuthError(
   'wallet_not_initialized',
   'Wallet is not initialized. Please run `await wallet.init(...)` before calling functions'
 )
 
-const InvalidAppId = new ArcanaWalletError(
+const InvalidAppId = new ArcanaAuthError(
   'invalid_constructor_params',
   'App Id is invalid.'
 )
@@ -21,5 +21,5 @@ export {
   InvalidAppId,
   UserNotLoggedInError,
   WalletNotInitializedError,
-  ArcanaWalletError,
+  ArcanaAuthError,
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,7 +26,7 @@ import {
   UserInfo,
 } from './typings'
 import { getAppInfo, getImageUrls } from './network'
-import { WalletNotInitializedError } from './errors'
+import { WalletNotInitializedError, ArcanaAuthError } from './errors'
 import {
   getLogger,
   Logger,
@@ -178,6 +178,12 @@ class AuthProvider {
    */
   public async getPublicKey(email: string) {
     if (this._provider) {
+      if (!email) {
+        throw new ArcanaAuthError(
+          'email_required',
+          'Email is required in params'
+        )
+      }
       return await this._provider.getPublicKey(email, 'google')
     }
     this.logger.error('requestPublicKey', WalletNotInitializedError)

--- a/src/index.ts
+++ b/src/index.ts
@@ -178,10 +178,10 @@ class AuthProvider {
    */
   public async getPublicKey(email: string) {
     if (this._provider) {
-      if (!email) {
+      if (!email || email === '') {
         throw new ArcanaAuthError(
           'email_required',
-          'Email is required in params'
+          `Email is required in getPublicKey, got ${email}`
         )
       }
       return await this._provider.getPublicKey(email, 'google')

--- a/src/typings.ts
+++ b/src/typings.ts
@@ -43,6 +43,8 @@ export interface UserInfo {
   email?: string
   name?: string
   picture?: string
+  address: string
+  publicKey: string
 }
 
 export interface ChildMethods {

--- a/usage.md
+++ b/usage.md
@@ -78,6 +78,8 @@ interface UserInfo {
   email?: string
   name?: string
   picture?: string
+  address: string
+  publicKey: string
 }
 */
 ```
@@ -88,7 +90,7 @@ Logout
 await auth.logout()
 ```
 
-### Get public key
+### Get public key associated with an email
 
 ```js
 await auth.getPublicKey(`${email}`)


### PR DESCRIPTION
# PR

## Describe your changes

- Added `address` and `publicKey` in `UserInfo` in `getUser` function
- Renamed `ArcanaWalletError` to `ArcanaAuthError`
- Handling missing `email` in `getPublicKey` function with error
- Updated docs for interface `UserInfo`
- Updated heading for `getPublicKey` function

## Issue ticket number and link

- [AR-3540](https://team-1624093970686.atlassian.net/browse/AR-3540)

## Checklist before requesting a review

- [x] You have performed a self-review of your own code
- [x] You are using approved terminology
- [x] Your changes have been tested locally
- [x] Your code builds clean without any errors or warnings
