### PR TITLE
[AR-2780] Logo not fit properly on Wallet bubble

### DIFF
--- a/src/styles.ts
+++ b/src/styles.ts
@@ -50,6 +50,7 @@ const widgetBubbleStyle = {
   bubbleLogo: {
     width: '40px',
     height: '40px',
+    objectFit: 'contain',
   },
   closeButton: {
     ...baseCloseButtonStyle,

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -49,7 +49,6 @@ const widgetBubbleStyle = {
   },
   bubbleLogo: {
     width: '40px',
-    height: '40px',
     objectFit: 'contain',
   },
   closeButton: {


### PR DESCRIPTION
## Changes
Set `object-fit` to `contain` for image in Bubble

## Issue ticket number and link

- [AR-2780](https://team-1624093970686.atlassian.net/browse/AR-2780)

Ref - https://www.loom.com/share/22c349e28d4c47edb793cc3b941d5c92

## Checklist before requesting a review

- [X] You have performed a self-review of your own code
- [X] You are using approved terminology
- [X] Your changes have been tested locally
- [X] Your code builds clean without any errors or warnings
