### PR TITLE
[AR-3442] fallback logo error

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -7,7 +7,8 @@ import * as Sentry from '@sentry/browser'
 import { getLogger } from './logger'
 import { InvalidAppId } from './errors'
 
-const fallbackLogo = '../images/fallback-logo.svg'
+const fallbackLogo =
+  'https://arcana-front.s3.ap-south-1.amazonaws.com/fallback-logo.svg'
 
 const getContract = (rpcUrl: string, appAddress: string) => {
   const provider = new ethers.providers.JsonRpcProvider(rpcUrl)


### PR DESCRIPTION
## Describe your changes
**Issue**: Fallback logo not found.

**Reason**: Using of relative path, when the bubble or the container displayed on the parent app, the logo is referenced with Parent app's URL

**Fix**: Hosted the image on AWS S3 and set the URL.

## Issue ticket number and link

- [AR-3442]](https://team-1624093970686.atlassian.net/browse/AR-3442])

## Checklist before requesting a review

- [X] You have performed a self-review of your own code
- [X] You are using approved terminology
- [X] Your changes have been tested locally
- [X] Your code builds clean without any errors or warnings
