### PR TITLE
[Hot-fix] add allow attribute for clipboard copy

### DIFF
--- a/src/iframeWrapper.ts
+++ b/src/iframeWrapper.ts
@@ -139,6 +139,7 @@ export default class IframeWrapper {
     this.iframe = createDomElement('iframe', {
       style: widgetIframeStyle.iframe,
       src: u.toString(),
+      allow: 'clipboard-write',
     }) as HTMLIFrameElement
 
     const { widgetIframeHeader, widgetIframeBody } =

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -77,7 +77,7 @@ const getArcanaRpc = async (gatewayUrl: string) => {
   }
 }
 
-type elements = 'style' | 'src' | 'onclick' | 'id' | 'onerror'
+type elements = 'style' | 'src' | 'onclick' | 'id' | 'onerror' | 'allow'
 
 const createDomElement = (
   type: string,


### PR DESCRIPTION
## Describe your changes

1. Need `allow` attribute in `iframe` element to use Clipboard API in navigator object.
2. Added allow attribute to `iframe` element.

## Checklist before requesting a review

- [X] You have performed a self-review of your own code
- [X] You are using approved terminology
- [X] Your changes have been tested locally
- [X] Your code builds clean without any errors or warnings
