### PR TITLE
[AR-4321] user closed popup error not thrown fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arcana/auth",
-  "version": "0.1.2-beta.8",
+  "version": "0.1.2-beta.9",
   "description": "Arcana Auth",
   "main": "dist/index.js",
   "module": "dist/standalone/auth.esm.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -221,7 +221,7 @@ class AuthProvider {
 
   private async beginLogin(
     url: string,
-    shouldPoll = false
+    shouldPoll = true
   ): Promise<ArcanaProvider> {
     const popup = new Popup(url, shouldPoll)
     await popup.open()


### PR DESCRIPTION
# PR

## Describe your changes

- `shouldPoll` value should default to `true` otherwise the popup closed by user is not thrown for social auth.

## Issue ticket number and link

- [AR-4321](https://team-1624093970686.atlassian.net/browse/AR-4321)

## Checklist before requesting a review

- [x] You have performed a self-review of your own code
- [x] You are using approved terminology
- [x] Your changes have been tested locally
- [x] Your code builds clean without any errors or warnings
