### PR TITLE
[Hotfix] Moving provider creation to constructor

### DIFF
--- a/examples/index.js
+++ b/examples/index.js
@@ -2,15 +2,15 @@ const { AuthProvider } = window.arcana.auth
 
 let provider
 const auth = new AuthProvider('...')
+provider = auth.provider
+setHooks()
 
 window.onload = async () => {
   try {
     console.time('auth_init')
     await auth.init()
     console.timeEnd('auth_init')
-    provider = auth.provider
     console.log('Init auth complete!')
-    setHooks()
   } catch (e) {
     console.log({ e })
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,6 +55,7 @@ class AuthProvider {
     this.networkConfig = getNetworkConfig(this.params.network)
     preLoadIframe(this.networkConfig.walletUrl, this.appId)
     this.rpcConfig = getRpcConfig(this.params.chainConfig, this.params.network)
+    this._provider = new ArcanaProvider(this.rpcConfig, this.setConnected)
 
     if (this.params.debug) {
       setLogLevel(LOG_LEVEL.DEBUG)
@@ -89,13 +90,7 @@ class AuthProvider {
 
       this.iframeWrapper.setWalletType(WalletType.UI, appMode)
 
-      this._provider = new ArcanaProvider(
-        this.iframeWrapper,
-        this.rpcConfig,
-        this.setConnected
-      )
-
-      await this._provider.init({
+      await this._provider.init(this.iframeWrapper, {
         loginWithLink: this.loginWithLink,
         loginWithSocial: this.loginWithSocial,
       })
@@ -115,7 +110,7 @@ class AuthProvider {
   }
 
   /**
-   * A function to open login modal
+   * A function to open login plug n play modal
    */
   public async connect(): Promise<EthereumProvider> {
     if (this.initStatus !== InitStatus.DONE) {
@@ -267,6 +262,9 @@ class AuthProvider {
     })
   }
 
+  /**
+   * @internal
+   */
   setConnected = () => {
     if (!this.connected) {
       this.connected = true

--- a/src/index.ts
+++ b/src/index.ts
@@ -96,12 +96,13 @@ class AuthProvider {
       })
       this.setProviders()
 
-      this.initStatus = InitStatus.DONE
-
-      this.resolveInitPromises()
       if (await this._provider.isLoggedIn()) {
         await this.waitForConnect()
       }
+
+      this.initStatus = InitStatus.DONE
+      this.resolveInitPromises()
+
       return this
     } else if (this.initStatus === InitStatus.RUNNING) {
       return await this.waitForInit()

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -52,17 +52,19 @@ export class ArcanaProvider
 {
   private communication: Connection<ChildMethods>
   private subscriber: SafeEventEmitter
+  private iframe: IframeWrapper
   private logger: Logger = getLogger('ArcanaProvider')
-  constructor(
-    private iframe: IframeWrapper,
-    private rpcConfig: RpcConfig,
-    private setConnected: () => void
-  ) {
+  constructor(private rpcConfig: RpcConfig, private setConnected: () => void) {
     super()
     this.subscriber = new SafeEventEmitter()
   }
 
-  public async init(loginFuncs: TriggerLoginFuncs) {
+  public isArcana() {
+    return true
+  }
+
+  public async init(iframe: IframeWrapper, loginFuncs: TriggerLoginFuncs) {
+    this.iframe = iframe
     const { communication } = await this.iframe.setConnectionMethods({
       onEvent: this.handleEvents,
       onMethodResponse: (


### PR DESCRIPTION
# PR

## Describe your changes

- Creating provider object in constructor so hooks can be applied before `auth.init()`
- Added `isArcana()` function on provider

## Checklist before requesting a review

- [x] You have performed a self-review of your own code
- [x] You are using approved terminology
- [x] Your changes have been tested locally
- [x] Your code builds clean without any errors or warnings
