### PR TITLE
[AR-5143] Remove showing social section if no providers configured

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arcana/auth",
-  "version": "0.2.3-beta.1",
+  "version": "0.2.3-beta.2",
   "description": "Arcana Auth",
   "main": "dist/standalone/auth.esm.js",
   "type": "module",

--- a/src/iframeWrapper.ts
+++ b/src/iframeWrapper.ts
@@ -62,6 +62,12 @@ export default class IframeWrapper {
     }
   }
 
+  public hideWidgetBubble() {
+    if (this.appMode === AppMode.Full) {
+      this.widgetBubble.style.display = 'none'
+    }
+  }
+
   public onReceivingPendingRequestCount(count: number) {
     const reqCountBadgeEl = document.getElementById('req-count-badge')
     if (!reqCountBadgeEl) {
@@ -111,7 +117,7 @@ export default class IframeWrapper {
     }
   }
 
-  private constructWidgetIframeStructure(isFullMode: boolean) {
+  private constructWidgetIframeStructure() {
     const {
       appConfig: { themeConfig },
     } = this.params
@@ -143,7 +149,7 @@ export default class IframeWrapper {
     return { widgetIframeHeader, widgetIframeBody }
   }
 
-  private createWidgetIframe(isFullMode: boolean) {
+  private createWidgetIframe() {
     const u = new URL(`/${this.params.appId}/login`, this.params.iframeUrl)
     this.iframe = createDomElement('iframe', {
       style: widgetIframeStyle.iframe,
@@ -152,7 +158,7 @@ export default class IframeWrapper {
     }) as HTMLIFrameElement
 
     const { widgetIframeHeader, widgetIframeBody } =
-      this.constructWidgetIframeStructure(isFullMode)
+      this.constructWidgetIframeStructure()
 
     widgetIframeBody.appendChild(this.iframe)
 
@@ -203,11 +209,7 @@ export default class IframeWrapper {
   }
 
   private initWalletUI() {
-    const isFullMode = this.appMode === AppMode.Full
-
-    this.widgetIframeContainer = this.createWidgetIframe(
-      isFullMode
-    ) as HTMLDivElement
+    this.widgetIframeContainer = this.createWidgetIframe() as HTMLDivElement
 
     this.widgetBubble = this.createWidgetBubble() as HTMLButtonElement
 
@@ -222,7 +224,7 @@ export default class IframeWrapper {
   }
 
   private onCloseBubbleClick() {
-    this.widgetBubble.style.display = 'none'
+    this.hideWidgetBubble()
   }
 
   // Todo: add remove event listener for "resize" event

--- a/src/index.ts
+++ b/src/index.ts
@@ -263,9 +263,12 @@ class AuthProvider {
   /**
    * @internal
    */
-  setConnected = () => {
+  setConnected = (isDisconnected?: boolean) => {
     if (!this.connected) {
       this.connected = true
+    }
+    if (isDisconnected) {
+      this.connected = false
     }
   }
 

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -54,7 +54,10 @@ export class ArcanaProvider
   private subscriber: SafeEventEmitter
   private iframe: IframeWrapper
   private logger: Logger = getLogger('ArcanaProvider')
-  constructor(private rpcConfig: RpcConfig, private setConnected: () => void) {
+  constructor(
+    private rpcConfig: RpcConfig,
+    private setConnected: (isDisconnected?: boolean) => void
+  ) {
     super()
     this.subscriber = new SafeEventEmitter()
   }
@@ -224,6 +227,8 @@ export class ArcanaProvider
         this.emit('connect', val)
         break
       case 'disconnect':
+        this.iframe.hideWidgetBubble()
+        this.setConnected(true)
         this.emit('disconnect', val)
         break
       case 'message':

--- a/src/typings.ts
+++ b/src/typings.ts
@@ -1,4 +1,4 @@
-import { JsonRpcRequest, JsonRpcResponse } from 'json-rpc-engine'
+import type { JsonRpcRequest, JsonRpcResponse } from 'json-rpc-engine'
 import { Chain } from './chainList'
 
 export type Theme = 'light' | 'dark'

--- a/src/ui/modal.tsx
+++ b/src/ui/modal.tsx
@@ -95,12 +95,16 @@ const Modal = (props: ModalParams) => {
           setEmail={setEmail}
           loginWithLink={linkLogin}
         />
-        <Separator text="or continue with" />
-        <SocialLogin
-          loginWithSocial={socialLogin}
-          loginList={props.loginList}
-          mode={props.mode}
-        />
+        {props.loginList.length > 0 ? (
+          <>
+            <Separator text="or continue with" />
+            <SocialLogin
+              loginWithSocial={socialLogin}
+              loginList={props.loginList}
+              mode={props.mode}
+            />
+          </>
+        ) : null}
       </Container>
     </Overlay>
   )


### PR DESCRIPTION
# PR

## Describe your changes

- Optional rendering of social section along with `or continue with` if no providers are configured.
- Added hiding on widget bubble and setting of `connected` flag to `false` on `disconnect` event.
- Fixed eslint warning for non-usage of `isFullMode`.

Old:
<img width="1424" alt="Screenshot 2022-11-30 at 10 11 22 AM" src="https://user-images.githubusercontent.com/51868969/204721332-b55aadfa-bb47-4f23-8dbe-3ea6842bb2f2.png">

New:
<img width="1418" alt="Screenshot 2022-11-30 at 10 10 32 AM" src="https://user-images.githubusercontent.com/51868969/204721316-cdc89144-aa10-4fac-b5b5-01bb90473ac9.png">

## Issue ticket number and link

- [AR-5143](https://team-1624093970686.atlassian.net/browse/AR-5143)

## Checklist before requesting a review

- [x] You have performed a self-review of your own code
- [x] You are using approved terminology
- [x] Your changes have been tested locally
- [x] Your code builds clean without any errors or warnings
