### PR TITLE
[Fix] Remove json rpc engine dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
     "husky": ">=6",
     "jest": "^29.0.0",
     "jest-environment-jsdom": "^29.2.0",
-    "json-rpc-engine": "^6.1.0",
     "lint-staged": ">=10",
     "node-stdlib-browser": "^1.2.0",
     "npm-run-all": "^4.1.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arcana/auth",
-  "version": "0.2.3-beta.2",
+  "version": "0.2.3-beta.3",
   "description": "Arcana Auth",
   "main": "dist/standalone/auth.esm.js",
   "type": "module",

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,13 +2,13 @@ import { ArcanaProvider } from './provider'
 import IframeWrapper from './iframeWrapper'
 import {
   getErrorReporter,
-  isDefined,
   constructLoginUrl,
   getCurrentUrl,
   getConstructorParams,
   removeHexPrefix,
   createOverlayOnRedirection,
   preLoadIframe,
+  validateClientId,
 } from './utils'
 import { getNetworkConfig, getRpcConfig } from './config'
 import {
@@ -47,12 +47,12 @@ class AuthProvider {
   private _provider: ArcanaProvider
   private connectCtrl: ModalController
   constructor(appAddress: string, p?: Partial<ConstructorParams>) {
-    if (!isDefined(appAddress)) {
-      throw new Error('appAddress is required')
-    }
+    validateClientId(appAddress)
+
     this.appId = removeHexPrefix(appAddress)
     this.params = getConstructorParams(p)
     this.networkConfig = getNetworkConfig(this.params.network)
+
     preLoadIframe(this.networkConfig.walletUrl, this.appId)
     this.rpcConfig = getRpcConfig(this.params.chainConfig, this.params.network)
     this._provider = new ArcanaProvider(this.rpcConfig, this.setConnected)

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -1,10 +1,12 @@
-import { ChildMethods, EthereumProvider, RpcConfig } from './typings'
-import type {
+import {
   JsonRpcId,
   JsonRpcRequest,
   JsonRpcError,
   JsonRpcResponse,
-} from 'json-rpc-engine'
+  ChildMethods,
+  EthereumProvider,
+  RpcConfig,
+} from './typings'
 import { Connection } from 'penpal'
 import { ethErrors } from 'eth-rpc-errors'
 import SafeEventEmitter from '@metamask/safe-event-emitter'

--- a/src/typings.ts
+++ b/src/typings.ts
@@ -1,4 +1,3 @@
-import type { JsonRpcRequest, JsonRpcResponse } from 'json-rpc-engine'
 import { Chain } from './chainList'
 
 export type Theme = 'light' | 'dark'
@@ -6,6 +5,42 @@ export type Theme = 'light' | 'dark'
 export type Orientation = 'horizontal' | 'vertical'
 
 export type Position = 'right' | 'left'
+
+/* json-rpc-engine types */
+export declare type JsonRpcVersion = '2.0'
+export declare type JsonRpcId = number | string | void
+
+export interface JsonRpcRequest<T> {
+  jsonrpc: JsonRpcVersion
+  method: string
+  id: JsonRpcId
+  params?: T
+}
+
+interface JsonRpcResponseBase {
+  jsonrpc: JsonRpcVersion
+  id: JsonRpcId
+}
+
+export interface JsonRpcFailure extends JsonRpcResponseBase {
+  error: JsonRpcError
+}
+
+export interface JsonRpcError {
+  code: number
+  message: string
+  data?: unknown
+  stack?: string
+}
+
+declare type Maybe<T> = Partial<T> | null | undefined
+
+export interface JsonRpcSuccess<T> extends JsonRpcResponseBase {
+  result: Maybe<T>
+}
+
+export type JsonRpcResponse<T> = JsonRpcSuccess<T> | JsonRpcFailure
+/* end of json-rpc-engine types */
 
 export enum InitStatus {
   CREATED,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -215,6 +215,23 @@ const redirectTo = (url: string) => {
 
 const isDefined = (arg: unknown) => arg !== undefined && arg !== null
 
+const isValidString = (arg: unknown): arg is string =>
+  typeof arg === 'string' && arg.trim().length > 0
+
+const isAddressLike = (arg: string) => removeHexPrefix(arg).length === 40
+
+const validateClientId = (arg: unknown) => {
+  if (!isDefined(arg)) {
+    throw new Error('appAddress is required')
+  }
+  if (!isValidString(arg)) {
+    throw new Error('appAddress is required to be a non-empty string')
+  }
+  if (!isAddressLike(arg)) {
+    throw new Error('appAddress is required to be an ethereum address')
+  }
+}
+
 const HEX_PREFIX = '0x'
 
 const addHexPrefix = (i: string) =>
@@ -396,7 +413,7 @@ export {
   verifyMode,
   preLoadIframe,
   getErrorReporter,
-  isDefined,
+  validateClientId,
   addHexPrefix,
   removeHexPrefix,
   redirectTo,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3184,7 +3184,7 @@ esutils@^2.0.2:
   resolved "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
 
-eth-rpc-errors@^4.0.2, eth-rpc-errors@^4.0.3:
+eth-rpc-errors@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/eth-rpc-errors/-/eth-rpc-errors-4.0.3.tgz#6ddb6190a4bf360afda82790bb7d9d5e724f423a"
   integrity sha512-Z3ymjopaoft7JDoxZcEb3pwdGh7yiYMhOwm2doUt6ASXlMavpNlK6Cre0+IMl2VSGyEU9rkiperQhp5iRxn5Pg==
@@ -4462,14 +4462,6 @@ json-parse-even-better-errors@^2.3.0:
   version "2.3.1"
   resolved "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz"
   integrity sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==
-
-json-rpc-engine@^6.1.0:
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/json-rpc-engine/-/json-rpc-engine-6.1.0.tgz#bf5ff7d029e1c1bf20cb6c0e9f348dcd8be5a393"
-  integrity sha512-NEdLrtrq1jUZyfjkr9OCz9EzCNhnRyWtt1PAnvnhwy6e8XETS0Dtc+ZNCO2gvuAoKsIn2+vCSowXTYE4CkgnAQ==
-  dependencies:
-    "@metamask/safe-event-emitter" "^2.0.0"
-    eth-rpc-errors "^4.0.2"
 
 json-schema-traverse@^0.4.1:
   version "0.4.1"


### PR DESCRIPTION
# PR

## Describe your changes

- Removing `json-rpc-engine` dependency for types, caused problems when importing types in other apps
- Added validation for `appAddress` - checks not `undefined` or `null`, not empty string and length === 40 without hex prefix
- Updated version

## Checklist before requesting a review

- [x] You have performed a self-review of your own code
- [x] You are using approved terminology
- [x] Your changes have been tested locally
- [x] Your code builds clean without any errors or warnings
