### PR TITLE
[Fix] fix hex prefix in blockchain call

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arcana/auth",
-  "version": "0.3.0",
+  "version": "1.0.0-beta.1",
   "description": "Arcana Auth",
   "main": "dist/standalone/auth.esm.js",
   "type": "module",

--- a/src/chainList.ts
+++ b/src/chainList.ts
@@ -6,8 +6,6 @@ export enum Chain {
   ETHEREUM_GOERLI = '0x5',
   POLYGON_MAINNET = '0x89',
   POLYGON_MUMBAI_TESTNET = '0x13881',
-  ARCANA_TESTNET = '0x9DD5',
-  ARCANA_DEV = '0x9DD4',
 }
 
 const ChainList: Record<Chain, RpcConfig> = {
@@ -60,18 +58,6 @@ const ChainList: Record<Chain, RpcConfig> = {
       symbol: 'matic',
       decimals: 18,
     },
-  },
-  [Chain.ARCANA_TESTNET]: {
-    chainId: Chain.ARCANA_TESTNET,
-    rpcUrls: ['https://blockchain001-testnet.arcana.network/'],
-    chainName: 'Arcana (Testnet)',
-    blockExplorerUrls: ['https://explorer.beta.arcana.network/'],
-  },
-  [Chain.ARCANA_DEV]: {
-    chainId: Chain.ARCANA_DEV,
-    rpcUrls: ['https://blockchain-dev.arcana.network'],
-    chainName: 'Arcana Dev',
-    blockExplorerUrls: ['https://explorer.dev.arcana.network/'],
   },
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,6 @@
 import { NetworkConfig, RpcConfig, ChainConfigInput } from './typings'
 import { Chain, getConfigFromChain } from './chainList'
-type Network = 'dev' | 'testnet'
+type Network = 'dev' | 'testnet' | 'mainnet'
 
 const DEV_NETWORK_CONFIG: NetworkConfig = {
   authUrl: 'https://verify.dev.arcana.network',
@@ -14,6 +14,12 @@ const TESTNET_NETWORK_CONFIG: NetworkConfig = {
   walletUrl: 'https://wallet.beta.arcana.network',
 }
 
+const MAINNET_NETWORK_CONFIG: NetworkConfig = {
+  authUrl: 'https://auth.arcana.network',
+  gatewayUrl: 'https://gateway.arcana.network',
+  walletUrl: 'https://wallet.arcana.network',
+}
+
 const getNetworkConfig = (n: Network | NetworkConfig) => {
   if (typeof n === 'string' && n == 'testnet') {
     return TESTNET_NETWORK_CONFIG
@@ -23,6 +29,10 @@ const getNetworkConfig = (n: Network | NetworkConfig) => {
     return DEV_NETWORK_CONFIG
   }
 
+  if (typeof n === 'string' && n == 'mainnet') {
+    return MAINNET_NETWORK_CONFIG
+  }
+
   if (isNetworkConfig(n)) {
     return n
   } else {
@@ -30,10 +40,7 @@ const getNetworkConfig = (n: Network | NetworkConfig) => {
   }
 }
 
-const getRpcConfig = (
-  c: ChainConfigInput | undefined,
-  n: Network | NetworkConfig
-): RpcConfig => {
+const getRpcConfig = (c: ChainConfigInput | undefined): RpcConfig => {
   if (isRpcConfigInput(c)) {
     const config = getConfigFromChain(c.chainId)
     if (c.rpcUrl) {
@@ -42,16 +49,7 @@ const getRpcConfig = (
     return config
   }
 
-  if (typeof n === 'string' && isNetworkEnum(n)) {
-    switch (n) {
-      case 'testnet':
-        return getConfigFromChain(Chain.ARCANA_TESTNET)
-      case 'dev':
-        return getConfigFromChain(Chain.ARCANA_DEV)
-    }
-  }
-
-  return getConfigFromChain(Chain.ARCANA_TESTNET)
+  return getConfigFromChain(Chain.ETHEREUM_MAINNET)
 }
 
 function isRpcConfigInput(
@@ -64,10 +62,6 @@ function isRpcConfigInput(
     return false
   }
   return true
-}
-
-function isNetworkEnum(n: string): n is Network {
-  return typeof n === 'string' && (n == 'testnet' || n == 'dev')
 }
 
 function isNetworkConfig(

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,7 +54,7 @@ class AuthProvider {
     this.networkConfig = getNetworkConfig(this.params.network)
 
     preLoadIframe(this.networkConfig.walletUrl, this.appId)
-    this.rpcConfig = getRpcConfig(this.params.chainConfig, this.params.network)
+    this.rpcConfig = getRpcConfig(this.params.chainConfig)
     this._provider = new ArcanaProvider(this.rpcConfig)
 
     if (this.params.debug) {

--- a/src/typings.ts
+++ b/src/typings.ts
@@ -140,7 +140,7 @@ export interface NetworkConfig {
 }
 
 export interface ChainConfigInput {
-  rpcUrl: string
+  rpcUrl?: string
   chainId: Chain
 }
 
@@ -172,7 +172,7 @@ export const ModeWalletTypeRelation = {
 }
 
 export interface ConstructorParams {
-  network: ('testnet' | 'dev') | NetworkConfig
+  network: ('testnet' | 'dev' | 'mainnet') | NetworkConfig
   debug: boolean
   alwaysVisible: boolean
   chainConfig?: ChainConfigInput

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -25,7 +25,7 @@ const fetchWalletType = async (rpcUrl: string, address: string) => {
     method: 'eth_call',
     params: [
       {
-        to: address,
+        to: addHexPrefix(address),
         data: '0x5b648b0a',
       },
       'latest',

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -239,7 +239,7 @@ const getCurrentUrl = () => {
 
 const getConstructorParams = (initParams?: Partial<ConstructorParams>) => {
   const p: ConstructorParams = {
-    network: 'testnet',
+    network: 'mainnet',
     debug: false,
     position: 'right',
     theme: 'dark',


### PR DESCRIPTION
# PR

## Describe your changes

- Added hex prefix in `to` for blockchain call
- Removed arcana chains, default to ethereum mainnet if not passed
- Added mainnet urls

## Checklist before requesting a review

- [x] You have performed a self-review of your own code
- [x] You are using approved terminology
- [x] Your changes have been tested locally
- [x] Your code builds clean without any errors or warnings
