### PR TITLE
[Hotfix] Make testnet as the default network

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,13 +69,13 @@ yarn add @arcana/auth
 
 # 📋 Prerequisites
 
-Before you can start using the Arcana Auth SDK, you need to register your dApp using [Arcana Developer Dashboard](https://dashboard.beta.arcana.network/).
+Before you can start using the Arcana Auth SDK, you need to register your dApp using [Arcana Developer Dashboard](https://dashboard.arcana.network/).
 
 A unique **App Address** will be assigned to your dApp and you need the same to initialize the Arcana Auth SDK.
 
 # 📚 Documentation
 
-Check out [Arcana Network documentation](https://docs.beta.arcana.network/) for [Auth SDK Quick Start Guide](https://docs.beta.arcana.network/docs/auth_qs), [Usage Guide](https://docs.beta.arcana.network/docs/auth_usage) and [API Reference Guide](https://authsdk-ref-guide.netlify.app).
+Check out [Arcana Network documentation](https://docs.arcana.network/) for [Auth SDK Quick Start Guide](https://docs.arcana.network/walletsdk/wallet_qs.html), [Usage Guide](https://docs.arcana.network/walletsdk/wallet_usage.html) and [API Reference Guide](https://authsdk-ref-guide.netlify.app).
 
 # 💡 Support
 
@@ -90,8 +90,3 @@ We welcome all contributions to the Arcana Auth SDK from the community. Read our
 Arcana Auth SDK is distributed under the [MIT License](https://fossa.com/blog/open-source-licenses-101-mit-license/).
 
 For details see [Arcana License](https://github.com/arcana-network/license/blob/main/LICENSE.md).
-
----
-> **Caution**
-> Arcana Auth SDK is in the Beta Release. Not recommended for production usage. 
----

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -239,7 +239,7 @@ const getCurrentUrl = () => {
 
 const getConstructorParams = (initParams?: Partial<ConstructorParams>) => {
   const p: ConstructorParams = {
-    network: 'mainnet',
+    network: 'testnet',
     debug: false,
     position: 'right',
     theme: 'dark',

--- a/usage.md
+++ b/usage.md
@@ -109,7 +109,7 @@ const auth = new AuthProvider(`${appAddress}`, {
   position: 'left',
   theme: 'light',
   alwaysVisible: false,
-  network: 'testnet', // network can be testnet or mainnet - defaults to mainnet
+  network: 'mainnet', // network can be testnet or mainnet - defaults to testnet
   chainConfig: {
     chainId: CHAIN.POLYGON_MAINNET,
     rpcUrl: '',


### PR DESCRIPTION
# PR

## Describe your changes

- `testnet` is the default network
- Updated dashboard, usage and qs link in `README.md`

## Checklist before requesting a review

- [x] You have performed a self-review of your own code
- [x] You are using approved terminology
- [x] Your changes have been tested locally
- [x] Your code builds clean without any errors or warnings
