### PR TITLE
Update Auth SDK Ref guide layout to the latest typedoc and better lay…

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,8 +83,10 @@
     "rollup-plugin-postcss": "^4.0.2",
     "rollup-plugin-terser": "^7.0.2",
     "ts-jest": "^29.0.3",
-    "typedoc": "^0.22.15",
+    "typedoc": "^0.25.7",
     "typedoc-plugin-extras": "^2.2.3",
+    "typedoc-plugin-rename-defaults": "^0.6.6",
+    "typedoc-theme-hierarchy": "^4.1.1",
     "typedoc-plugin-markdown": "^3.12.1",
     "typescript": "^4.3.5"
   },

--- a/typedoc-theme/an_style.css
+++ b/typedoc-theme/an_style.css
@@ -1,0 +1,74 @@
+@import url('https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@100;200;300;400;500;600;700;800&family=Inter:wght@100;200;300;400&display=block');
+
+:root > * {
+  font-family: 'Inter';
+  font-size: 14px;
+}
+
+.tsd-page-toolbar {
+  border: 0;
+  border-radius: 5px;
+}
+
+.tsd-theme-toggle {
+  padding-top: 0.75rem;
+}
+.tsd-theme-toggle > h4 {
+  display: inline;
+  vertical-align: middle;
+  margin-right: 0.75rem;
+}
+
+.tsd-generator > p {
+  font-style: italic;
+}
+
+pre > button {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  opacity: 0;
+  transition: opacity 0.1s;
+  box-sizing: border-box;
+  border: 0;
+}
+
+code,
+pre {
+  font-family: Menlo, Monaco, Consolas, 'Courier New', monospace;
+  padding: 0.4rem;
+  margin: 0;
+  font-size: 0.75rem;
+  border: 0;
+  border-radius: 0.8em;
+}
+
+h1 {
+  font-size: 1.5rem;
+  margin: 0.67rem 0;
+}
+
+h2 {
+  font-size: 1.2rem;
+  margin: 0.83rem 0;
+}
+
+h3 {
+  font-size: 1rem;
+  margin: 1rem 0;
+}
+
+h4 {
+  font-size: 0.85rem;
+  margin: 1.33rem 0;
+}
+
+h5 {
+  font-size: 0.8rem;
+  margin: 1.5rem 0;
+}
+
+h6 {
+  font-size: 0.7rem;
+  margin: 2.33rem 0;
+}

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,5 +1,6 @@
 {
   "entryPoints": ["src/index.ts"],
+  "entryPointStrategy": "expand",
   "name": "Auth SDK Reference Guide",
   "out": "docs",
   "excludePrivate": true,
@@ -8,5 +9,6 @@
   "excludeInternal": true,
   "includeVersion": true,
   "hideGenerator": true,
-  "plugin": ["typedoc-plugin-markdown"]
+  "plugin": ["typedoc-plugin-extras", "typedoc-plugin-rename-defaults", "typedoc-theme-hierarchy"],
+  "theme": "hierarchy"
 }

--- a/typedochtml.json
+++ b/typedochtml.json
@@ -1,5 +1,6 @@
 {
   "entryPoints": ["src/index.ts"],
+  "entryPointStrategy": "expand",
   "name": "Auth SDK Reference Guide",
   "out": "htmldocs",
   "excludePrivate": true,
@@ -8,5 +9,7 @@
   "includeVersion": true,
   "footerDate": true,
   "footerTime": true,
-  "plugin": ["typedoc-plugin-extras"]
+  "plugin": ["typedoc-plugin-extras", "typedoc-plugin-rename-defaults", "typedoc-theme-hierarchy"],
+  "theme": "hierarchy",
+  "customCss": "./typedoc-theme/an_style.css"
 }


### PR DESCRIPTION
…out theme

# PR

## Describe your changes

Use a better Auth SDK Ref theme and layout. We made this update in Sept but somehow missed merging to dev so it wasn't there in the 1.0.9-rc1 candidate branch.

Here is how it shows up after the updates to typedoc configs:

<img width="1316" alt="Screenshot 2024-01-11 at 9 12 33 PM" src="https://github.com/arcana-network/auth/assets/5890484/acaed305-2db3-4a9f-b8e2-c1ab3ad8e895">


## Issue ticket number and link

- [AR-XXX](https://team-1624093970686.atlassian.net/browse/AR-XXX)
- [XXXX](https://github.com/arcana-network/auth/issues/XXXX)

## Checklist before requesting a review

- [ ] You have performed a self-review of your own code
- [ ] You are using approved terminology
- [ ] Your changes have been tested locally
- [ ] Your code builds clean without any errors or warnings
